### PR TITLE
Updated send email to handle html body

### DIFF
--- a/py_utils/utils.py
+++ b/py_utils/utils.py
@@ -91,7 +91,15 @@ def send_email(
     msg["Subject"] = subject
     msg["From"] = sender
     msg["To"] = ", ".join(recipients)
-    msg.set_content(body, subtype='html')
+
+    pattern = r"<[^>]*>"
+
+    if re.search(pattern, body) is not None:
+        print("HTML DETECTED")
+        msg.set_content(body, subtype='html')
+    else:
+        print("NORMAL STRING")
+        msg.set_content(body)
 
     if file:
         for f in file:

--- a/py_utils/utils.py
+++ b/py_utils/utils.py
@@ -91,7 +91,7 @@ def send_email(
     msg["Subject"] = subject
     msg["From"] = sender
     msg["To"] = ", ".join(recipients)
-    msg.set_content(body)
+    msg.set_content(body, subtype='html')
 
     if file:
         for f in file:

--- a/py_utils/utils.py
+++ b/py_utils/utils.py
@@ -95,10 +95,8 @@ def send_email(
     pattern = r"<[^>]*>"
 
     if re.search(pattern, body) is not None:
-        print("HTML DETECTED")
         msg.set_content(body, subtype='html')
     else:
-        print("NORMAL STRING")
         msg.set_content(body)
 
     if file:


### PR DESCRIPTION
**What does this change do?** _Please be clear and concise._

Changes `send_email()` function to handle `html` content in the body. Strings in body have no impact and render as usual.

**Why was this change made?** _Including an issue number is sufficient. Otherwise, briefly explain the benefit of the change._

`send_email()` parsed the html code in the body as string and sent the complete code instead of rendering the html. 


## Verification

NA

## Affirmations

All of these should have a check by them. Any exception requires an explanation.

* [x] I have added docstrings with details on keyword arguments to new functions following the convention detailed in this [gist](https://gist.github.com/mbentz-uf/0433c32f260a0a06f57a9ff32fcef252)
* [x] I have added type hinting to new function parameters.
* [x] I have added tests to new functions, following the rules of [F.I.R.S.T.](https://wiki.ctsi.ufl.edu/books/testing/page/how-to-write-python-unit-tests).
* [x] I matched the style of the existing code.
* [x] I added and updated any relevant documentation (inline, `README`, `CHANGELOG`, and such).
* [x] I used Python's type hinting.
* [x] I ran the automated tests and ensured they **ALL** passed.
* [x] I ran the linter and ensured my changes have not introduced **ANY** warnings or errors.
* [x] I have made an effort to minimize code changes and have not included any cruft (preference files, *.pyc files, old comments, print-debugging, unused variables).
* [x] I have made an effort maintain a clear commit history (haven't merged other branches or rebased improperly).
* [x] I have written the code myself or have given credit where credit is due.
