### PR TITLE
Add _contains_html function

### DIFF
--- a/py_utils/utils.py
+++ b/py_utils/utils.py
@@ -6,6 +6,23 @@ import re
 import smtplib
 
 
+def _contains_html(content: str) -> bool:
+    """Utility function that checks if the content contains html.
+
+    Args:
+        content (str): The content to test for html.
+
+    Returns:
+        bool: Returns True if the content contains html, and False otherwise.
+    """
+    pattern = r"<[^>]*>"
+
+    if re.search(pattern, content) is not None:
+        return True
+    else:
+        return False
+
+
 def directory_exists(path_to_dir: str) -> bool:
     """Checks if the directory exists
 
@@ -92,9 +109,7 @@ def send_email(
     msg["From"] = sender
     msg["To"] = ", ".join(recipients)
 
-    pattern = r"<[^>]*>"
-
-    if re.search(pattern, body) is not None:
+    if _contains_html(body):
         msg.set_content(body, subtype='html')
     else:
         msg.set_content(body)

--- a/tests/py_utils/test_utils.py
+++ b/tests/py_utils/test_utils.py
@@ -9,6 +9,13 @@ class TestUtils(unittest.TestCase):
     first_duplicate_file_name = 'get_unique_filename_test (1).file'
     second_duplicate_file_name = 'get_unique_filename_test (2).file'
 
+    def test_contains_html(self):
+        html_markup = "<html><p></p></html>"
+        non_html_text = "This is a sentence with special characters, < ? ! . '"
+
+        self.assertEquals(True, utils._contains_html(html_markup))
+        self.assertEquals(False, utils._contains_html(non_html_text))
+
     def test_get_unique_filename_base(self):
         self.assertEquals(utils.get_unique_filename(
             self.original_file_name), self.original_file_name)


### PR DESCRIPTION
**What does this change do?** 

Adds `_contains_html` function with unit tests.

**Why was this change made?** 

To close #3.

## Verification


1. Verify the logic of the test_contains_html unit test
2. Verify that all automated workflows pass

- Verify the thing does this: ...
- Verify the thing does not do that: ...


## Affirmations

All of these should have a check by them. Any exception requires an explanation.

* [x] I have added docstrings with details on keyword arguments to new functions following the convention detailed in this [gist](https://gist.github.com/mbentz-uf/0433c32f260a0a06f57a9ff32fcef252)
* [x] I have added type hinting to new function parameters.
* [x] I have added tests to new functions, following the rules of [F.I.R.S.T.](https://wiki.ctsi.ufl.edu/books/testing/page/how-to-write-python-unit-tests).
* [x] I matched the style of the existing code.
* [x] I added and updated any relevant documentation (inline, `README`, `CHANGELOG`, and such).
* [x] I used Python's type hinting.
* [x] I ran the automated tests and ensured they **ALL** passed.
* [x] I ran the linter and ensured my changes have not introduced **ANY** warnings or errors.
* [x] I have made an effort to minimize code changes and have not included any cruft (preference files, *.pyc files, old comments, print-debugging, unused variables).
* [x] I have made an effort maintain a clear commit history (haven't merged other branches or rebased improperly).
* [x] I have written the code myself or have given credit where credit is due.
