### PR TITLE
Fix update_model function

### DIFF
--- a/tests/py_utils/test_orm.py
+++ b/tests/py_utils/test_orm.py
@@ -95,7 +95,7 @@ class TestOrm(unittest.TestCase):
         actual = Image(**updated_data)
 
         created_image = self.db_client.insert_data(image)
-        updated_image = self.db_client.update_model(created_image, **{"core": "dc"})
+        updated_image = self.db_client.update_model(model=created_image, values={"core": created_image.core})
 
         expected = Image(**convert_model_to_dict(updated_image))
 


### PR DESCRIPTION
**What does this change do?** 

Fixes the `update_model` function.

**Why was this change made?** 

Passing kwargs as the last parameter was causing `update_model` to not behave as expected when not explicitly setting pk_field.


## Verification

1. Verify that all automated tests pass
2. Debug and step through `test_orm` to make sure the logic is sound
- Verify the thing does this: ...
- Verify the thing does not do that: ...


## Affirmations

All of these should have a check by them. Any exception requires an explanation.

* [x] I have added docstrings with details on keyword arguments to new functions following the convention detailed in this [gist](https://gist.github.com/mbentz-uf/0433c32f260a0a06f57a9ff32fcef252)
* [x] I have added type hinting to new function parameters.
* [x] I have added tests to new functions, following the rules of [F.I.R.S.T.](https://wiki.ctsi.ufl.edu/books/testing/page/how-to-write-python-unit-tests).
* [x] I matched the style of the existing code.
* [x] I added and updated any relevant documentation (inline, `README`, `CHANGELOG`, and such).
* [x] I used Python's type hinting.
* [x] I ran the automated tests and ensured they **ALL** passed.
* [x] I ran the linter and ensured my changes have not introduced **ANY** warnings or errors.
* [x] I have made an effort to minimize code changes and have not included any cruft (preference files, *.pyc files, old comments, print-debugging, unused variables).
* [x] I have made an effort maintain a clear commit history (haven't merged other branches or rebased improperly).
* [x] I have written the code myself or have given credit where credit is due.
