### PR TITLE
Add eager loading support for `query_model` and deprecate `update_model`

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,6 +11,7 @@ packages = [{ include = "py_utils" }]
 python = "^3.11"
 sqlalchemy = "^2.0.20"
 sqlmodel = "^0.0.12"
+deprecated = "^1.2.14"
 
 [tool.poetry.urls]
 "Homepage" = "https://github.com/ctsit/PyUtils"


### PR DESCRIPTION
**What does this change do?** _Please be clear and concise._

Add eager loading support for `query_model` and deprecate `update_model`

**Why was this change made?** 

Eager loading support simplifies making changes and interacting with the database.

## Verification

1. Verify that all automated workflows pass.
2. Verify that the logic of `test_update_model` is sound.

## Affirmations

All of these should have a check by them. Any exception requires an explanation.

* [x] I have added docstrings with details on keyword arguments to new functions following the convention detailed in this [gist](https://gist.github.com/mbentz-uf/0433c32f260a0a06f57a9ff32fcef252)
* [x] I have added type hinting to new function parameters.
* [x] I have added tests to new functions, following the rules of [F.I.R.S.T.](https://wiki.ctsi.ufl.edu/books/testing/page/how-to-write-python-unit-tests).
* [x] I matched the style of the existing code.
* [x] I added and updated any relevant documentation (inline, `README`, `CHANGELOG`, and such).
* [x] I used Python's type hinting.
* [x] I ran the automated tests and ensured they **ALL** passed.
* [x] I ran the linter and ensured my changes have not introduced **ANY** warnings or errors.
* [x] I have made an effort to minimize code changes and have not included any cruft (preference files, *.pyc files, old comments, print-debugging, unused variables).
* [x] I have made an effort maintain a clear commit history (haven't merged other branches or rebased improperly).
* [x] I have written the code myself or have given credit where credit is due.
