### PR TITLE
Add tests for `ScriptHelper`

### DIFF
--- a/tests/py_utils/test_utils.py
+++ b/tests/py_utils/test_utils.py
@@ -1,10 +1,13 @@
+import sqlite3
 import unittest
 import os
 
 from py_utils import utils
+from py_utils.orm import DbClient
 
 
 class TestUtils(unittest.TestCase):
+    test_db = "tests/db.sqlite"
     original_file_name = 'get_unique_filename_test.file'
     first_duplicate_file_name = 'get_unique_filename_test (1).file'
     second_duplicate_file_name = 'get_unique_filename_test (2).file'
@@ -33,7 +36,37 @@ class TestUtils(unittest.TestCase):
             utils.get_unique_filename(self.original_file_name),
             self.second_duplicate_file_name)
 
+    def test_script_helper_signature(self):
+        """
+        This test checks if log_failed_job and log_successful_job log status of data
+        correctly. This calls the functions and saves it to local .sqlite file and checks
+        if everything is inserted into the db correctly.
+        """
+        db_client = DbClient(f"sqlite:///{self.test_db}")
+        script_helper = utils.ScriptHelper("test_signature.py", db_client)
+        script_helper.log_failed_job({"info": "Could not write into sheet"}, "File not found")
+        script_helper.log_successful_job({"info": "File written"})
+
+        conn = sqlite3.connect(self.test_db)
+        cur = conn.cursor()
+
+        count_job_status_data = 0
+        for i, row in enumerate(cur.execute("SELECT * FROM job_status")):
+            count_job_status_data += 1
+            self.assertEqual(row[5], "test_signature.py")
+            self.assertIsInstance(row[9], int)
+            self.assertNotEqual(len(row[10]), 0)
+            if i == 0:
+                self.assertEqual(row[11], 'ERROR')
+            elif i == 1:
+                self.assertEqual(row[11], 'INFO')
+
+        self.assertEqual(count_job_status_data, 2)
+        conn.close()
+
     def tearDown(self):
+        if os.path.exists(self.test_db):
+            os.remove(self.test_db)
         if os.path.isfile(self.original_file_name):
             os.remove(self.original_file_name)
 


### PR DESCRIPTION
**What does this change do?**

Adds tests for `ScriptHelper`

**Why was this change made?** 

This should have been a part of #16, but was left out.

## Verification

1. Verify that all tests pass

## Affirmations

All of these should have a check by them. Any exception requires an explanation.

* [x] I have added docstrings with details on keyword arguments to new functions following the convention detailed in this [gist](https://gist.github.com/mbentz-uf/0433c32f260a0a06f57a9ff32fcef252)
* [x] I have added type hinting to new function parameters.
* [x] I have added tests to new functions, following the rules of [F.I.R.S.T.](https://wiki.ctsi.ufl.edu/books/testing/page/how-to-write-python-unit-tests).
* [x] I matched the style of the existing code.
* [x] I added and updated any relevant documentation (inline, `README`, `CHANGELOG`, and such).
* [x] I used Python's type hinting.
* [x] I ran the automated tests and ensured they **ALL** passed.
* [x] I ran the linter and ensured my changes have not introduced **ANY** warnings or errors.
* [x] I have made an effort to minimize code changes and have not included any cruft (preference files, *.pyc files, old comments, print-debugging, unused variables).
* [x] I have made an effort maintain a clear commit history (haven't merged other branches or rebased improperly).
* [x] I have written the code myself or have given credit where credit is due.
