### PR TITLE
Make fields nullable and increase job summary data length

### DIFF
--- a/py_utils/models.py
+++ b/py_utils/models.py
@@ -16,15 +16,15 @@ class JobStatus(SQLModel, table=True):
     id: Optional[int] = Field(default=None, primary_key=True)
     created_date: datetime = Field(default=datetime.utcnow(), nullable=False)
     modified_date: datetime = Field(default_factory=datetime.utcnow, nullable=False)
-    host: str
-    script_path: str
-    script_name: str
-    executed_by: str
-    script_start_time: datetime
-    script_end_time: datetime
-    elapsed_time: int
-    job_summary_data: str
-    level: JobStatusLevels
+    host: str = Field(nullable=True)
+    script_path: str = Field(nullable=True)
+    script_name: str = Field(nullable=True)
+    executed_by: str = Field(nullable=True)
+    script_start_time: datetime = Field(nullable=True)
+    script_end_time: datetime = Field(nullable=True)
+    elapsed_time: int = Field(nullable=True)
+    job_summary_data: str = Field(nullable=True, max_length=15000)
+    level: JobStatusLevels = Field(nullable=True)
 
     def __str__(self):
         return (


### PR DESCRIPTION
**What does this change do?** 

This PR updates `JobStatus` fields to be nullable and increases the size of `job_summary_data`.

**Why was this change made?**

This change supports inputting more data into the `job_summary_data` field. 

## Verification
As these are only field-level changes:
1. Verify that all automated tests still pass

## Affirmations

All of these should have a check by them. Any exception requires an explanation.

* [x] I have added docstrings with details on keyword arguments to new functions following the convention detailed in this [gist](https://gist.github.com/mbentz-uf/0433c32f260a0a06f57a9ff32fcef252)
* [x] I have added type hinting to new function parameters.
* [x] I have added tests to new functions, following the rules of [F.I.R.S.T.](https://wiki.ctsi.ufl.edu/books/testing/page/how-to-write-python-unit-tests).
* [x] I matched the style of the existing code.
* [x] I added and updated any relevant documentation (inline, `README`, `CHANGELOG`, and such).
* [x] I used Python's type hinting.
* [x] I ran the automated tests and ensured they **ALL** passed.
* [x] I ran the linter and ensured my changes have not introduced **ANY** warnings or errors.
* [x] I have made an effort to minimize code changes and have not included any cruft (preference files, *.pyc files, old comments, print-debugging, unused variables).
* [x] I have made an effort maintain a clear commit history (haven't merged other branches or rebased improperly).
* [x] I have written the code myself or have given credit where credit is due.
