### PR TITLE
Added Report Data table

### DIFF
--- a/py_utils/models.py
+++ b/py_utils/models.py
@@ -1,7 +1,9 @@
 from datetime import datetime
 from enum import Enum
 from sqlmodel import Field, SQLModel
-from typing import Optional
+from typing import Optional, List
+from sqlmodel import Relationship
+from datetime import timezone
 
 
 class JobStatusLevels(str, Enum):
@@ -25,6 +27,8 @@ class JobStatus(SQLModel, table=True):
     elapsed_time: int = Field(nullable=True)
     job_summary_data: str = Field(nullable=True, max_length=15000)
     level: JobStatusLevels = Field(nullable=True)
+    report_data: List["ReportData"] = Relationship(
+        back_populates="job_status", sa_relationship_kwargs={"lazy": "joined"})
 
     def __str__(self):
         return (
@@ -34,3 +38,32 @@ class JobStatus(SQLModel, table=True):
             f" start_time: {self.script_start_time}, end_time: {self.script_end_time},"
             f" elapsed_time: {self.elapsed_time}"
         )
+
+
+class ReportData(SQLModel, table=True):
+    __tablename__: str = "report_data"
+
+    id: Optional[int] = Field(default=None, primary_key=True)
+    report_data: Optional[str] = Field(default='', max_length=16000)
+    report_name: Optional[str] = Field(default='')
+    date_generated: datetime = Field(default=datetime.now(timezone.utc), nullable=False)
+    script_name: Optional[str] = Field()
+    report_size: Optional[int] = Field(default=0)
+    job_status_id: Optional[int] = Field(default=None, foreign_key="job_status.id")
+    job_status: JobStatus = Relationship(back_populates="report_data")
+
+    def __str__(self):
+        return (
+            f"id: {self.id},"
+            f"report_data: {self.report_data}, report_name: {self.report_name},"
+            f"date_generated: {self.date_generated}, script_name: {self.script_name}"
+        )
+
+    def __eq__(self, other):
+        return self.id == other.id and self.report_data == other.report_data and \
+            self.report_name == other.report_name and self.date_generated == other.date_generated and \
+            self.script_name == other.script_name and self.job_status_id == other.job_status_id
+
+    def __hash__(self):
+        return hash((self.id, self.report_data, self.report_name, self.date_generated, self.script_name,
+                     self.job_status_id))

--- a/py_utils/utils.py
+++ b/py_utils/utils.py
@@ -175,7 +175,7 @@ class ScriptHelper():
         job_status = self._get_job_status_of_type(summary_data, error, False)
         self._db_client.insert_data(job_status)
 
-    def log_successful_job(self, summary_data: dict):
+    def log_successful_job(self, summary_data: dict) -> JobStatus:
         """Attempt to log a successful `JobStatus` entry to the log database.
 
         Args:
@@ -183,6 +183,7 @@ class ScriptHelper():
         """
         job_status = self._get_job_status_of_type(summary_data, "", True)
         self._db_client.insert_data(job_status)
+        return job_status
 
     def _get_job_status_of_type(self, summary_data: Dict, error: str, succeeded: bool):
         level = JobStatusLevels.INFO if succeeded else JobStatusLevels.ERROR


### PR DESCRIPTION
This change adds a ReportData table in the model definitions and defines its relationship to JobStatus in models.py. This functionality allows us to store reports that are generated in PyCustodian so that they can be recreated at a later point in time.

This change also adds a return for successful job entry so that the job id and script name from it can be added to the reports table.

**What does this change do?** _Please be clear and concise._
Adds a report data table and a return for the log_successful_job function. 

**Why was this change made?** _Including an issue number is sufficient. Otherwise, briefly explain the benefit of the change._

To allow us to store reports in a MySQL database.

## Verification

_List the steps needed to make sure this thing works. Be precise._

- Verify the thing does this: All the unit tests are passing, logic for the table definition looks good.


## Affirmations

All of these should have a check by them. Any exception requires an explanation.

* [x] I have added docstrings with details on keyword arguments to new functions following the convention detailed in this [gist](https://gist.github.com/mbentz-uf/0433c32f260a0a06f57a9ff32fcef252)
* [x] I have added type hinting to new function parameters.
* [ ] I have added tests to new functions, following the rules of [F.I.R.S.T.](https://wiki.ctsi.ufl.edu/books/testing/page/how-to-write-python-unit-tests).
* [x] I matched the style of the existing code.
* [x] I added and updated any relevant documentation (inline, `README`, `CHANGELOG`, and such).
* [x] I used Python's type hinting.
* [x] I ran the automated tests and ensured they **ALL** passed.
* [x] I ran the linter and ensured my changes have not introduced **ANY** warnings or errors.
* [x] I have made an effort to minimize code changes and have not included any cruft (preference files, *.pyc files, old comments, print-debugging, unused variables).
* [x] I have made an effort maintain a clear commit history (haven't merged other branches or rebased improperly).
* [x] I have written the code myself or have given credit where credit is due.
