### PR TITLE
Add log level to `StreamHandler`

### DIFF
--- a/py_utils/log_config.py
+++ b/py_utils/log_config.py
@@ -28,14 +28,17 @@ def configure_logging(handlers: List[logging.Handler] = [], verbose: bool = Fals
     formatter = logging.Formatter(fmt)
 
     logger = logging.getLogger()
-    logger.setLevel(logging.INFO)
+
+    log_level = logging.INFO
     if verbose:
-        logger.setLevel(logging.DEBUG)
+        log_level = logging.DEBUG
+
+    logger.setLevel(log_level)
 
     # create stream handler
     stream_handler = logging.StreamHandler(sys.stderr)
     stream_handler.setFormatter(formatter)
-    stream_handler.setLevel(logging.INFO)
+    stream_handler.setLevel(log_level)
 
     # create a file handler
     file_handler = logging.FileHandler(utils.get_unique_filename(log_filename))


### PR DESCRIPTION
**What does this change do?** 

Set the log level of the `StreamHandler`.

**Why was this change made?** 

The logs to the console did not contain `DEBUG` log entries. Updating the log level of the `StreamHandler` fixes this.

## Verification
Run the sample script in PyCustodian with the latest changes to test.

1. In PyCustodian checkout [PR 109](https://github.com/ctsit/PyCustodian/pull/109/files#diff-50c86b7ed8ac2cf95bd48334961bf0530cdc77b5a56f852c5c61b89d735fd711)
2.  In `pyproject.toml` replace `tag = "2.3.1"` with `rev = "9fd646c272336af7d436ddcc9fcad7c284e255d6"`
    - https://github.com/ctsit/PyCustodian/blob/f45aa0617f6f0511501f5ecf4203c6a53dfb366f/pyproject.toml#L16
4. Run `poetry upgrade`
5. Run the sample script with and without the verbose flag
    - `py-custodian run sample_script.py`
    - `py-custodian run sample_script.py --verbose`
   
Verify that the logs contain DEBUG entries when the script is run using the `--verbose` flag, and are not included when run without the `--verbose` flag.

## Affirmations

All of these should have a check by them. Any exception requires an explanation.

* [ ] I have added docstrings with details on keyword arguments to new functions following the convention detailed in this [gist](https://gist.github.com/mbentz-uf/0433c32f260a0a06f57a9ff32fcef252)
* [ ] I have added type hinting to new function parameters.
* [ ] I have added tests to new functions, following the rules of [F.I.R.S.T.](https://wiki.ctsi.ufl.edu/books/testing/page/how-to-write-python-unit-tests).
* [ ] I matched the style of the existing code.
* [ ] I added and updated any relevant documentation (inline, `README`, `CHANGELOG`, and such).
* [ ] I used Python's type hinting.
* [x] I ran the automated tests and ensured they **ALL** passed.
* [x] I ran the linter and ensured my changes have not introduced **ANY** warnings or errors.
* [x] I have made an effort to minimize code changes and have not included any cruft (preference files, *.pyc files, old comments, print-debugging, unused variables).
* [x] I have made an effort maintain a clear commit history (haven't merged other branches or rebased improperly).
* [x] I have written the code myself or have given credit where credit is due.
